### PR TITLE
enable × on selects

### DIFF
--- a/JqueryChosen/files/chosen.css
+++ b/JqueryChosen/files/chosen.css
@@ -76,7 +76,8 @@
     display: block;
     width: 12px;
     height: 12px;
-    font-size: 1px
+    font-size: 1px;
+    background: url(plugin_file.php?file=JqueryChosen/chosen-sprite.png) no-repeat -42px 1px
 }
 
 .chosen-container-single .chosen-single abbr:hover {


### PR DESCRIPTION
the background-information was for .chosen-container-single .chosen-single abbr was missing. therefore the × was not shown in dropdowns with empty options