### PR TITLE
Added visual feedback after failed HTML form validation

### DIFF
--- a/JqueryChosen/JqueryChosen.php
+++ b/JqueryChosen/JqueryChosen.php
@@ -29,7 +29,8 @@ class JqueryChosenPlugin extends MantisPlugin {
 		$resources = '<link rel="stylesheet" type="text/css" href="' . plugin_file( 'chosen.css') . '" />' .
 					'<script type="text/javascript" src="' . plugin_page( 'chosen_js_params' ) . '"></script> '.
 					'<script type="text/javascript" src="' . plugin_file( 'chosenmin.js' ) . '"></script> '.
-					'<script type="text/javascript" src="' . plugin_file( 'chosen.js' ) . '"></script> ';
+					'<script type="text/javascript" src="' . plugin_file( 'chosen.js' ) . '"></script> '.
+					'<script type="text/javascript" src="' . plugin_file( 'chosen_html_validation_fix.js' ) . '"></script> ';
 		return  $resources;
 	}
 }

--- a/JqueryChosen/files/chosen.css
+++ b/JqueryChosen/files/chosen.css
@@ -70,13 +70,14 @@
 }
 
 .chosen-container-single .chosen-single abbr {
+    background: rgba(0, 0, 0, 0) url(plugin_file.php?file=JqueryChosen/chosen-sprite.png) no-repeat scroll -42px 1px;
     position: absolute;
     top: 6px;
     right: 26px;
     display: block;
     width: 12px;
     height: 12px;
-    font-size: 1px
+    font-size: 1px;
 }
 
 .chosen-container-single .chosen-single abbr:hover {
@@ -417,7 +418,7 @@
     .chosen-container-multi .chosen-choices .search-choice .search-choice-close,
     .chosen-container .chosen-results-scroll-down span,
     .chosen-container .chosen-results-scroll-up span {
-        background-image: url(chosen-sprite@2x.png) !important;
+        background-image: url(chosen-sprite.png) !important;
         background-size: 52px 37px !important;
         background-repeat: no-repeat !important
     }

--- a/JqueryChosen/files/chosen.js
+++ b/JqueryChosen/files/chosen.js
@@ -11,9 +11,24 @@ specific language governing permissions and limitations under the License.
 */
 
 jQuery(function($){
-	$("select").attr("data-placeholder",SELECTION_ONE_OPTION).chosen({
-		no_results_text: NO_RESULTS,
-		allow_single_deselect:true
-	}).addClass("chosen-plugin-auto-hide");
+	$("select").each(function() {
+
+		var element_width = this.offsetWidth;
+
+		// calculate width of elements that are not visible
+		if(!$(this).is(":visible")) {
+			var clone = $(this).clone();
+			clone.css("visibility","hidden");
+			$('body').append(clone);
+			element_width = clone.outerWidth();
+			clone.remove();
+		}
+
+		$(this).attr("data-placeholder", SELECTION_ONE_OPTION).chosen({
+			no_results_text: NO_RESULTS,
+			allow_single_deselect: true,
+			width: element_width + 60
+		}).addClass("chosen-plugin-auto-hide");
+
+	});
 });
- 

--- a/JqueryChosen/files/chosen_html_validation_fix.js
+++ b/JqueryChosen/files/chosen_html_validation_fix.js
@@ -1,0 +1,26 @@
+$(document).ready(function() {
+
+	// add tooltip for required but invalid fields
+	$("select.chosen-plugin-auto-hide[required]").each(function()  {
+		$(this).on("invalid", function() {
+			var item = $(this).next("div");
+			item.css("border","1px solid orange");
+			item.attr("title",REQUIRED).tooltip({
+				content: REQUIRED
+			}).mouseover();
+
+			// remove tooltip when changes are made
+			$(this).on("change", function() {
+				$(this).next("div")
+					.css("border","none")
+					.removeAttr("title").tooltip("destroy");
+			});
+
+		});
+
+
+
+	});
+
+
+});

--- a/JqueryChosen/files/chosenmin.js
+++ b/JqueryChosen/files/chosenmin.js
@@ -150,7 +150,7 @@
 				return a.results_search()
 			}, 50)
 		}, AbstractChosen.prototype.container_width = function () {
-			return null != this.options.width ? this.options.width : "" + (this.form_field.offsetWidth + 60) + "px"
+			return (this.options.width ? this.options.width : "" + (this.form_field.offsetWidth + 60)) + "px"
 		}, AbstractChosen.prototype.include_option_in_results = function (a) {
 			return this.is_multiple && !this.display_selected_options && a.selected ? !1 : !this.display_disabled_options && a.disabled ? !1 : a.empty ? !1 : !0
 		}, AbstractChosen.prototype.search_results_touchstart = function (a) {

--- a/JqueryChosen/pages/chosen_js_params.php
+++ b/JqueryChosen/pages/chosen_js_params.php
@@ -4,7 +4,9 @@
 
 	$SELECTION_ONE_OPTION = plugin_lang_get("selectionOneOption");
 	$NO_RESULTS = plugin_lang_get("noResults");
+	$REQUIRED = lang_get("required");
 
 
 	echo "var SELECTION_ONE_OPTION = '".$SELECTION_ONE_OPTION."'; ";
 	echo "var NO_RESULTS = '".$NO_RESULTS."'; ";
+	echo "var REQUIRED = '".$REQUIRED."'; ";


### PR DESCRIPTION
MantisBT changed form validation to HTML validation and there was no visual feedback for missing required fields that are affected by Chosen. Now there is a tooltip shown when a required select field is empty or invalid